### PR TITLE
Add handling for non-UTF-8 character sets.

### DIFF
--- a/enc_test.go
+++ b/enc_test.go
@@ -1,0 +1,12 @@
+package goxpath
+
+import (
+	"testing"
+)
+
+func TestISO_8859_1(t *testing.T) {
+	p := `/test`
+	x := `<?xml version="1.0" encoding="iso-8859-1"?><test>test<path>path</path>test2</test>`
+	exp := []string{"testpathtest2"}
+	execVal(p, x, exp, nil, t)
+}

--- a/tree/xmltree/xmltree.go
+++ b/tree/xmltree/xmltree.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/net/html/charset"
+
 	"github.com/ChrisTrenkamp/goxpath/tree"
 	"github.com/ChrisTrenkamp/goxpath/tree/xmltree/internal"
 	"github.com/ChrisTrenkamp/goxpath/tree/xmltree/result/xmlele"
@@ -53,6 +55,7 @@ func ParseXML(r io.Reader, op ...ParseSettings) (tree.Node, error) {
 	}
 
 	dec := xml.NewDecoder(r)
+	dec.CharsetReader = charset.NewReaderLabel
 	dec.Strict = ov.Strict
 
 	ordrPos := 1


### PR DESCRIPTION
Use golang.org/x/net/html/charset's NewReaderLabel to handle the charset.
I'm not sure if it handles everything, but at least it copes with
ISO-8859-1.

Without this weird charsets get a `xml: encoding "iso-8859-1" declared but Decoder.CharsetReader is nil` error.