### PR TITLE
Conversion validation improvement

### DIFF
--- a/goxpath.go
+++ b/goxpath.go
@@ -77,16 +77,11 @@ func (xp XPathExec) ExecNum(t tree.Node, opts ...FuncOpts) (float64, error) {
 	}
 
 	n, ok := res.(tree.IsNum)
-	if !ok {
+	if !ok || math.IsNaN(float64(n.Num())) {
 		return 0, fmt.Errorf("Cannot convert result to a number")
 	}
 
-	v := float64(n.Num())
-	if math.IsNaN(v) {
-		return 0, fmt.Errorf("Cannot convert result to a number")
-	}
-
-	return v, nil
+	return float64(n.Num()), nil
 }
 
 //ExecNode is like Exec, except it will attempt to return the result as a node-set.

--- a/goxpath.go
+++ b/goxpath.go
@@ -3,6 +3,7 @@ package goxpath
 import (
 	"encoding/xml"
 	"fmt"
+	"math"
 
 	"github.com/ChrisTrenkamp/goxpath/internal/execxp"
 	"github.com/ChrisTrenkamp/goxpath/parser"
@@ -80,7 +81,12 @@ func (xp XPathExec) ExecNum(t tree.Node, opts ...FuncOpts) (float64, error) {
 		return 0, fmt.Errorf("Cannot convert result to a number")
 	}
 
-	return float64(n.Num()), nil
+	v := float64(n.Num())
+	if math.IsNaN(v) {
+		return 0, fmt.Errorf("Cannot convert result to a number")
+	}
+
+	return v, nil
 }
 
 //ExecNode is like Exec, except it will attempt to return the result as a node-set.


### PR DESCRIPTION
The function ExecNum should return an error when try convert result to a number instead return ok (or nil).